### PR TITLE
Fixed compatibility issue with Microsoft Visual C++ 14.0 for Python 3.5+

### DIFF
--- a/KrovetzStemmer.hpp
+++ b/KrovetzStemmer.hpp
@@ -17,6 +17,7 @@
 #include <iostream>
 #include <cstring>
 #if defined(_WIN32)
+#define _SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS
 #include <hash_map>
 #elif defined(__clang__)
 #include <tr1/unordered_map>


### PR DESCRIPTION
Hi,
When installing for Python 3.6 on Windows with Microsoft Visual C++, I got this error:
```
C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\INCLUDE\hash_map(17):
    error C2338: <hash_map> is deprecated and will be REMOVED. Please use <unordere
d_map>. You can define _SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS to acknowledge
that you have received this warning.
    error: command 'C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\B
IN\\x86_amd64\\cl.exe' failed with exit status 2
```
I added the specified define directive and now it is installed and working fine.